### PR TITLE
Updated requirements in composer.json to SS 3.1 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     ],
     "require":
     {
-        "silverstripe/framework": "3.*",
-	    "silverstripe/cms": "3.*"
+        "silverstripe/framework": ">=3.1.x-dev,<4.0",
+	    "silverstripe/cms": ">=3.1.x-dev,<4.0"
     },
     "replace": {"silverstripe/dashboard": "*"},
 


### PR DESCRIPTION
As the master branch now only works on SS 3.1, I've updated the composer.json requirements so that composer will know never to install this branch on a SS 3.0 site.
