### PR TITLE
BUGFIX: Define $tree_class property

### DIFF
--- a/code/Dashboard.php
+++ b/code/Dashboard.php
@@ -28,6 +28,10 @@ class Dashboard extends LeftAndMain implements PermissionProvider {
 	
 	
 	private static $menu_icon = "dashboard/images/dashboard.png";
+	
+	
+	
+	private static $tree_class = 'DashboardPanel';
 
 
 	


### PR DESCRIPTION
Define the `$tree_class` property. This tells the framework that `Dashboard` manages `DashboardPanel` objects. This is used by the [Subsites](https://github.com/silverstripe/silverstripe-subsites) module to check permissions. So is required for compatibility.
