### PR TITLE
Allow GridField / ModelAdmin panels to have their own templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 The Dashboard module provides a splash page for the CMS in SilverStripe 3 with configurable widgets that display relevant information. Panels can be created and extended easily. The goal of the Dashboard module is to provide users with a launchpad for common CMS actions such as creating specific page types or browsing new content.
 
-Videos can also be found at [in this blog post.](http://www.leftandmain.com/silverstripe-screencasts/2012/10/03/dashboard-module-for-silverstripe-3/)
 
-## Screenshot
-![Screenshot](http://www.leftandmain.com/wp-content/themes/bueno/thumb.php?src=wp-content/uploads/2012/10/screenshot.png&w=640&zc=1&q=90)
+## Screenshot & Videos
+Images and videos about this module can be found [in this blog post.](http://www.leftandmain.com/silverstripe-screencasts/2012/10/03/dashboard-module-for-silverstripe-3/)
 
 
 ## Included panels
@@ -104,6 +103,8 @@ public function PanelHolder() {
 }
 ```
 
+
+
 ### Adding a chart to visualize data
 
 The Dashboard module comes with an API for creating charts using the Google API.
@@ -129,5 +130,21 @@ The Dashboard module comes with an API for creating charts using the Google API.
 ```html
 $Chart
 ```
+
+### Custom templates for ModelAdmin / GridField panels
+
+You can create your own templates for either of these panel types which will override the default templates. Due to the naming structure the custom templates will be specific to that partiular panel, thus you can have a seperate template for each ModelAdmin / GridField panel.
+
+You can access all the properties of your model in the template as normal along with a EditLink method which will contain the CMS edit link for that item.
+
+
+For model admin panels, create a templated called DashboardModelAdminPanel\_**ModelAdminClass**\_**ModelAdminModel**.ss and place it in your _mysite/templates/Includes folder_. 
+eg;
+**DashboardModelAdminPanel\_MyAdmin\_Product.ss**
+
+A gridfield panel uses a similar convention, DashboardGridFieldPanel\_**PageClassName**\_**GridFieldName**.ss
+
+eg;
+**DashboardGridFieldPanel\_ContactPage\_Submissions.ss**
 
 

--- a/code/panels/DashboardGridFieldPanel.php
+++ b/code/panels/DashboardGridFieldPanel.php
@@ -38,6 +38,22 @@ class DashboardGridFieldPanel extends DashboardPanel {
 
 
 	/**
+	 * Override to check if there is a custom template for this panel, otherwise fall back.
+	 *
+	 * @return string
+	 */
+	protected function getTemplate() {
+		$templateName = get_class($this) . '_' . $this->SubjectPage()->ClassName . '_' . $this->GridFieldName;
+		if(SS_TemplateLoader::instance()->findTemplates($templateName)) {
+			return $templateName;
+		}
+		return parent::getTemplate();
+	}
+
+
+
+
+	/**
 	 * @var string Overrides the standard request handler to provide custom controller actions
 	 */
 	protected $requestHandlerClass = "DashboardGridField_PanelRequest";
@@ -275,19 +291,17 @@ class DashboardGridFieldPanel extends DashboardPanel {
 				->sort("LastEdited DESC");
 			$ret = ArrayList::create(array());
 			foreach($list as $record) {
-				$ret->push(ArrayData::create(array(
-					'EditLink' => Controller::join_links(
-										Injector::inst()->get("CMSMain")->Link("edit"),
-										"EditForm",
-										"field",
-										$this->GridFieldName,
-										"item",
-										$record->ID,
-										"edit",
-										"?ID={$this->SubjectPageID}"
-									),
-					'Title' => $record->getTitle()
-				)));
+				$record->EditLink = Controller::join_links(
+					Injector::inst()->get("CMSMain")->Link("edit"),
+					"EditForm",
+					"field",
+					$this->GridFieldName,
+					"item",
+					$record->ID,
+					"edit",
+					"?ID={$this->SubjectPageID}"
+				);
+				$ret->push($record);
 			}
 			return $ret;
 		}

--- a/code/panels/DashboardModelAdminPanel.php
+++ b/code/panels/DashboardModelAdminPanel.php
@@ -39,6 +39,21 @@ class DashboardModelAdminPanel extends DashboardPanel {
 
 
 
+	/**
+	 * Override to check if there is a custom template for this panel, otherwise fall back
+	 *
+	 * @return string
+	 */
+	protected function getTemplate() {
+		$templateName = get_class($this) . '_' . $this->ModelAdminClass . '_' . $this->ModelAdminModel;
+		if(SS_TemplateLoader::instance()->findTemplates($templateName)) {
+			return $templateName;
+		}
+		return parent::getTemplate();
+	}
+
+
+
 	public function getLabel() {
 		return _t('Dashboard.MODELADMINPANELTITLE','Model Admin Editor');
 	}
@@ -228,20 +243,17 @@ class DashboardModelAdminPanel extends DashboardPanel {
 			$url_segment = Injector::inst()->get($this->ModelAdminClass)->Link();
 			$ret = ArrayList::create(array());
 			foreach($records as $rec) {
-				$ret->push(ArrayData::create(array(
-					'EditLink' => Controller::join_links(
-									$url_segment, 
-									$this->ModelAdminModel,
-									"EditForm",
-									"field",
-									$this->ModelAdminModel,
-									"item",
-									$rec->ID,
-									"edit"
-								),
-					'Title' => $rec->getTitle()
-
-				)));
+				$rec->EditLink = Controller::join_links(
+					$url_segment,
+					$this->ModelAdminModel,
+					"EditForm",
+					"field",
+					$this->ModelAdminModel,
+					"item",
+					$rec->ID,
+					"edit"
+				);
+				$ret->push($rec);
 			}
 			return $ret;
 		}


### PR DESCRIPTION
I have some panels where just the Title isn't good enough. With contact for submissions I also want to see the date of the submission.

Updated the two panels to check and use a custom template if there is one. Since the template name uses elements from the config it means the panels can have their own templates.

Updated the methods which get the items so the whole object is passed back to the template - with the EditLink added to the object so that can still be used.

Removed the screen shot from the README as github didn't like it.
