### PR TITLE
DashboardPanels.ss: Fix primary & secondary actions.

### DIFF
--- a/templates/UncleCheese/Dashboard/DashboardPanel.ss
+++ b/templates/UncleCheese/Dashboard/DashboardPanel.ss
@@ -4,7 +4,7 @@
 			<% if $PrimaryActions %>
 				<div class="dashboard-panel-header-actions">
 					<% loop $PrimaryActions %>
-						$Action
+						$Action.RAW <%-- $Action contains HTML, do not escape it. --%>
 					<% end_loop %>
 				</div>
 			<% end_if %>
@@ -24,7 +24,7 @@
 			<% if $SecondaryActions %>
 				<div class="dashboard-panel-footer-actions">
 					<% loop $SecondaryActions %>
-						$Action
+						$Action.RAW <%-- $Action contains HTML, do not escape it. --%>
 					<% end_loop %>
 				</div>
 			<% end_if %>


### PR DESCRIPTION
These broke during the SS4 upgrade. SS3 did not escape HTML by default, but SS4 does (generally a good thing), but for these actions, escaping needs to be turned off.