### PR TITLE
Fix GridFieldPanel "Create new" button on SS3.7

### DIFF
--- a/code/panels/DashboardGridFieldPanel.php
+++ b/code/panels/DashboardGridFieldPanel.php
@@ -199,11 +199,11 @@ class DashboardGridFieldPanel extends DashboardPanel {
 			return Controller::join_links(
 				Injector::inst()->get("CMSMain")->Link("edit"),
 				"EditForm",
+				$this->SubjectPageID,
 				"field",
 				$this->GridFieldName,
 				"item",
-				"new",
-				"?ID={$this->SubjectPageID}"
+				"new"
 			);
 		}
 	}


### PR DESCRIPTION
Passes the page ID in the URL rather than as a query parameter to fix the "Create new" buttons on GridFieldPanels when used with Silverstripe 3.7. 